### PR TITLE
Added anchor in title for accessibility

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,9 @@
     <div id="header_wrap" class="outer">
         <header class="inner">
 
-          <h1 id="project_title" onclick="location.href='/';" style="cursor: pointer;"><img class="logo" src="/assets/svg/gf_logo_without_label.svg" alt = "logo" width="200"> {{ site.title | default: site.github.repository_name }}</h1>
+          <h1 id="project_title" style="cursor: pointer;">
+		    <a href="/" style="text-decoration: none;"><img class="logo" src="/assets/svg/gf_logo_without_label.svg" alt = "logo" width="200"> {{ site.title | default: site.github.repository_name }}</a>
+		  </h1>
           <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
 
 


### PR DESCRIPTION
Currently, the page header reroutes the page using a `onclick` on the `<h1>` title. ([link here](https://github.com/gridfinity-unofficial/gridfinity-unofficial.github.io/blob/387734966b3e69a59373465d353dd73443dd5576/_layouts/default.html#L29)). This has the following accessibility issues:
1. You cannot click with the middle mouse button to open in a new tab
2. You cannot select the header using the `Tab` key in the keyboard, which is a problem to users that navigate the web with a keyboard
3. It's not semantic. Can be a problem to screen readers to detect there is a link there

The simple solution I added here is to replace it with a simple `<a>` tag.

I couldn't really run the project on my machine, so it's not really tested. But this is simple enough to be probably working. But the warning is here.