### PR TITLE
Increase catalog page table default pageLength from 10 to 50

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -27,6 +27,7 @@ permalink: /catalog/
         console.log(list);
         $('#catalogTable').dataTable( {
             "data": list,
+            "pageLength": 50,
             "columns": [
                 {"title": "Part", "data": null,
                   render: function(data) {


### PR DESCRIPTION
Increase catalog table's default pageLength (items per page) from 10 to 50 to fit all currently available products.

The JQuery DataTable defaults to only showing 10 items per page. This means that 23 of the 33 Gridfinity entries are not visible.

After change

<img width="951" alt="image" src="https://github.com/gridfinity-unofficial/gridfinity-unofficial.github.io/assets/20095477/20e89098-326b-4751-84d7-41322e437713">
