### PR TITLE
Add helpful links (generators, patreon, subreddit) and address some common confusion

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,4 +4,4 @@ plugins:
 markdown: kramdown
 
 title: "Gridfinity"
-description: The modular, open-source grid storage system for your workshop.
+description: The modular, open-source grid storage system.

--- a/faq.html
+++ b/faq.html
@@ -67,29 +67,6 @@ permalink: /faq/
   </div>
 </section>
 
-
-
-
-
-<h2>Publishing and creating own designs</h2>
-
-<section>
-    <div class="container">
-        <div class="accordion">
-            <div class="accordion-item" id="question4">
-                <a class="accordion-link" href="#question4">
-                    What is the best way to publish my own designs?
-                </a>
-                <div class="answer">
-                    <p>
-                        TODO:  description template for Thangs
-                    </p>
-                </div>
-            </div>
-        </div>
-    </div>
-</section>
-
 <h2>Where to buy non-printable parts (affiliate links supporting Zack)</h2>
 
 <ul>
@@ -117,7 +94,7 @@ permalink: /faq/
                 </a>
                 <div class="answer">
                     <p>
-                        Be a Patreon of Zack, Contribute to this site at ,...
+                        Become a patron on <a href="https://www.patreon.com/zackfreedman">Zack's Patreon</a>, contribute to this site, share your models, and visit the <a href="https://www.reddit.com/r/gridfinity">active subreddit</a>!
                     </p>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@ title: "Gridfinity :: Unofficial wiki"
 
 <h3>Get started with online generators!</h3>
 <ul>
-  <li><a href="https://gridfinity.perplexinglabs.com">Generate custom bins, baseplates, and more with Perplexing Labs</a></li>
-  <li><a href="https://gridfinitygenerator.com">Design bins and baseplates with gridfinity generator</a></li>
+  <li><a href="https://gridfinity.perplexinglabs.com">Perplexing Labs' Gridfinity Generator</a><br/>Generate custom bins, baseplates, lids, and more - just input your dimensions!</li>
+  <li><a href="https://gridfinitygenerator.com">Design bins and baseplates with gridfinitygenerator.com</a></li>
 </ul>
 
 <h3>The best things in life are integer multiples of 42x42x7mm.</h3>

--- a/index.html
+++ b/index.html
@@ -5,11 +5,6 @@ title: "Gridfinity :: Unofficial wiki"
 
 <!-- This section is the 'jumbotron', where users first look. -->
 <section>
-  <div class="alert alert-info">
-    <i class="fa fa-info"></i>
-    <b>This site is a work in progress!</b> Come join us on <a href="https://discord.com/invite/voidstarlab">#gridfinity</a> in Zack's discord to help!
-  </div>
-
   <p class="jumbo-link-section">
     <a class="jumbo-link" href="/catalog">
       <img src="/assets/svg/catalog_img.svg" width="200" height="200" alt="Gridfinity catalog">
@@ -42,3 +37,9 @@ title: "Gridfinity :: Unofficial wiki"
 
   <p>Now Gridfinity is in the hands of a thriving community that continually adapts it to their needs. We invite you to join this community by using and adapting the system!</p>
 </section>
+
+<div class="alert alert-info">
+  <i class="fa fa-info"></i>
+  <b>This site is a work in progress!</b> Come join us on <a href="https://discord.com/invite/voidstarlab">#gridfinity</a> in Zack's discord to help!
+</div>
+

--- a/index.html
+++ b/index.html
@@ -18,8 +18,13 @@ title: "Gridfinity :: Unofficial wiki"
     </a>
 
   </p>
-
 </section>
+
+<h3>Get started with online generators!</h3>
+<ul>
+  <li><a href="https://gridfinity.perplexinglabs.com">Generate custom bins, baseplates, and more with Perplexing Labs</a></li>
+  <li><a href="https://gridfinitygenerator.com">Design bins and baseplates with gridfinity generator</a></li>
+</ul>
 
 <h3>The best things in life are integer multiples of 42x42x7mm.</h3>
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@ title: "Gridfinity :: Unofficial wiki"
 <section>
   <p> Alexander Chappels <a href="https://www.thingiverse.com/thing:4160638" target="_blank" rel="noopener noreferrer">Assortment System</a>, licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener noreferrer">CC-A-NC-SA</a>,
     partly inspired <a href="https://www.youtube.com/c/ZackFreedman" target="_blank" rel="noopener noreferrer">Zack Freedman's</a> initial designs of Gridfinity. The Gridfinity designs were first released
-    in the video <a href="https://www.youtube.com/watch?v=ra_9zU-mnl8" target="_blank" rel="noopener noreferrer">"Gridfinity: Your Ultimate Modular Workshop is FREE!"</a> as a framework for the community to extend.</p>
+    in the video <a href="https://www.youtube.com/watch?v=ra_9zU-mnl8" target="_blank" rel="noopener noreferrer">"Gridfinity: Your Ultimate Modular Workshop is FREE!"</a> as a framework for the community to extend, released under the MIT license.</p>
 
     <div class = "video-container" >
     <iframe width="560" height="315" src="https://www.youtube.com/embed/ra_9zU-mnl8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
Addresses #33 by adding two big gridfinity generator websites.

Addresses #26 by mentioning MIT licensing.

Additional items:
- Simplified site tagline for cleaner + faster look
- Added link to Zack's Patreon under FAQ > Support
- Added link to gridfinity subreddit, which is very active and growing
- Moved the "This site is a work in progress join us on discord" notice on front page down a bit since it's not quite as useful as the other materials, initially