### PR TITLE
Fix nix development environment

### DIFF
--- a/gemset.nix
+++ b/gemset.nix
@@ -314,4 +314,14 @@
     };
     version = "1.8.0";
   };
+  webrick = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1d4cvgmxhfczxiq5fr534lmizkhigd15bsx5719r5ds7k7ivisc7";
+      type = "gem";
+    };
+    version = "1.7.0";
+  };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -9,5 +9,5 @@ let
   };
 in stdenv.mkDerivation {
   name = "your-package";
-  buildInputs = [env ruby_3_1];
+  buildInputs = [env ruby_3_1 bundix];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,12 +2,12 @@ with (import <nixpkgs> {});
 let
   env = bundlerEnv {
     name = "your-package";
-    inherit ruby;
+    ruby = ruby_3_1;
     gemfile = ./Gemfile;
     lockfile = ./Gemfile.lock;
     gemset = ./gemset.nix;
   };
 in stdenv.mkDerivation {
   name = "your-package";
-  buildInputs = [env ruby];
+  buildInputs = [env ruby_3_1];
 }


### PR DESCRIPTION
## Summary

Improves the nix-shell development environment to ensure compatibility and maintainability:

1. **Pin Ruby version to 3.1** - Explicitly specifies ruby_3_1 for compatibility with current gem dependencies
2. **Add bundix to shell.nix** - Includes bundix in the development environment for gem maintenance
3. **Add webrick to gemset.nix** - Regenerated gemset.nix to include missing webrick gem required by Jekyll

## Motivation

- Ruby 3.3 is incompatible with Jekyll 4.2.2
- Ruby 3.2 removed the `tainted?` method, which is still used by Liquid 4.0.3
- Ruby 3.1 is compatible with all current dependencies
- The webrick gem was listed in Gemfile and Gemfile.lock but missing from gemset.nix, causing bundler to fail when running Jekyll
- bundix needs to be available for developers to regenerate gemset.nix when updating gems

These changes prevent future breakage when developers use newer nixpkgs versions and ensure the development tooling is complete.

## Testing

- Cleared nix store to verify fresh builds work correctly
- Confirmed Jekyll server starts successfully with Ruby 3.1
- Verified the site builds and serves at http://localhost:4000
- Tested that webrick is properly installed and Jekyll runs without errors