### PR TITLE
Add build instructions to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .jekyll-cache/
 _site/
+vendor/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # Unofficial Gridfinity website
 The WIP homepage of the unofficial gridfinity site.
+
+Want to contribute? Join us on [#gridfinity](https://discord.com/invite/voidstarlab) in Zack's discord to help!
+
+## Building the project locally
+
+This project is built using the [Jekyll](https://jekyllrb.com/) static site generator.
+
+In order to build the project locally, you will first need to install the requirements for Jekyll. Instructions for your
+specific operating system can be found [here](https://jekyllrb.com/docs/installation/).
+
+Once Ruby is installed, you will need to install Bundler by running `gem install bundler` in your command line.
+
+With bundler installed, you can simply navigate to the project's directory and run `bundle install` to install all 
+required gems.
+
+With all gems installed, you can start serving jekyll locally using `bundle exec jekyll serve`.


### PR DESCRIPTION
Add instructions of how to build the site locally to the readme, so that other contributors can check their changes locally.