### PR TITLE
Update index.html to fix simple spelling/grammar mistake

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ title: "Gridfinity :: Unofficial wiki"
 
 <h3>Origins of Gridfinity</h3>
 <section>
-  <p> Alexander Chappels <a href="https://www.thingiverse.com/thing:4160638" target="_blank" rel="noopener noreferrer">Assortment System</a>, licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener noreferrer">CC-A-NC-SA</a>,
+  <p> Alexandre Chappel's <a href="https://www.thingiverse.com/thing:4160638" target="_blank" rel="noopener noreferrer">Assortment System</a>, licensed under <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="noopener noreferrer">CC-A-NC-SA</a>,
     partly inspired <a href="https://www.youtube.com/c/ZackFreedman" target="_blank" rel="noopener noreferrer">Zack Freedman's</a> initial designs of Gridfinity. The Gridfinity designs were first released
     in the video <a href="https://www.youtube.com/watch?v=ra_9zU-mnl8" target="_blank" rel="noopener noreferrer">"Gridfinity: Your Ultimate Modular Workshop is FREE!"</a> as a framework for the community to extend, released under the MIT license.</p>
 


### PR DESCRIPTION
The first name of the creator of the original Assortment System isn't "Alexander," but rather "Alexandre" (at least, this is how he spells his name on the name of his YouTube channel).

Also, you need an apostrophe before the possessive s in "Alexandre Chappel's Assortment System."