### PR TITLE
Add Gridfinity Layout Tool to online generators

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@ title: "Gridfinity :: Unofficial wiki"
   <li><a href="https://gridfinity.bouwens.co/">GridfinityCreator lets you generate STL or STEP files for several types of customizable Gridfinity components.</a></li>
   <li><a href="https://extrabold.tools">Extrabold.tools</a><br/>A modern, fast fullfeatured Gridfinity baseplate generator focused on ease-of-use, real-time previews, and printer-aware STL generation.</li>
   <li><a href="https://tooltrace.ai/">tooltrace.ai</a><br/>A free custom-holder Gridfinity generator that works by tracing a photo of your tool(s) on a piece of A4 or letter paper.</li>
+  <li><a href="https://gridfinitylayouttool.com">Gridfinity Layout Tool</a><br/>A visual drawer layout planner for designing where bins go before you print them. Features multi-layer support, drag-and-drop placement, 3D preview, and print optimization.</li>
 </ul>
 
 <h3>You're a developer? Get started with some code!</h3>


### PR DESCRIPTION
Hi! I'd like to add my tool to the online generators section.

**Gridfinity Layout Tool** (https://gridfinitylayouttool.com) is a visual drawer layout planner for designing where bins go before you print them.

Features include:
- Multi-layer support
- Drag-and-drop bin placement
- 3D isometric preview
- Print optimization with filament estimation

Thanks for maintaining this community resource!