### PR TITLE
Add GridfinityStudio to online generators

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@ title: "Gridfinity :: Unofficial wiki"
   <li><a href="https://extrabold.tools">Extrabold.tools</a><br/>A modern, fast fullfeatured Gridfinity baseplate generator focused on ease-of-use, real-time previews, and printer-aware STL generation.</li>
   <li><a href="https://tooltrace.ai/">tooltrace.ai</a><br/>A free custom-holder Gridfinity generator that works by tracing a photo of your tool(s) on a piece of A4 or letter paper.</li>
   <li><a href="https://gridfinitylayouttool.com">Gridfinity Layout Tool</a><br/>A visual drawer layout planner for designing where bins go before you print them. Features multi-layer support, drag-and-drop placement, 3D preview, and print optimization.</li>
+  <li><a href="https://gridfinitystudio.com">GridfinityStudio</a><br/>A 3D drawer-first Gridfinity planner for designing complete layouts before you print. Customize bins and holders, generate baseplates, import existing STLs, and export print-ready files.</li>
 </ul>
 
 <h3>You're a developer? Get started with some code!</h3>


### PR DESCRIPTION
Hi! I'd like to add GridfinityStudio to the online generators section.

**GridfinityStudio** (https://gridfinitystudio.com) is a drawer first Gridfinity planner for designing complete layouts in 3D before printing. Essentially a digital 3d playground for gridfinity. 

Features include:
- Full-drawer 3D planning
- Custom bins and holders
- Baseplate generation
- Existing STL import
- Print-ready exports

It's been getting positive feedback from the Gridfinity community on Reddit:
https://www.reddit.com/r/gridfinity/comments/1uyfnvx/comment/p6ma0he/?context=3

GridfinityStudio also had about 280 visitors in the last 30 days, so it is starting to see real usage outside of just my own testing.

_Since I know paid tools can be a concern in the Gridfinity community, I also want to be upfront that GridfinityStudio does have paid plans. The free plan is not a trial, and we have no intention of removing it. Core drawer planning, bins, baseplates, STL imports, and individual exports remain available free. Paid plans focus on more advanced workflow features like stacked baseplates, AI tool tracing, full-project exports, and larger-project organization. I have paid plans as one-time purchases that give users lifetime access, mostly just to support the server costs of the free plan and pay me a little bit for my time. _

Thanks for maintaining this community resource!